### PR TITLE
🐛 Add timeout when rcon closing and support for folia

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ _✨ Minecraft 协议适配 ✨_
 
 - [`原版端`](https://www.minecraft.net/zh-hans/download/server)
 - [`Spigot`](https://www.spigotmc.org/)
-- [`Fabric`](https://fabricmc.net/)
+- [`Folia`](https://papermc.io/software/folia)
 - [`Forge`](https://files.minecraftforge.net/)
+- [`Fabric`](https://fabricmc.net/)
 - [`NeoForge`](https://neoforged.net/)
 - [`Velocity`](https://papermc.io/software/velocity)
 
@@ -27,7 +28,7 @@ _✨ Minecraft 协议适配 ✨_
 
 ## Rcon支持
 
-对于命令采用 `rcon` 发送，`rcon` 库为 [`aio-mc-rcon`](https://github.com/Iapetus-11/aio-mc-rcon)
+命令采用 `rcon` 发送，`rcon` 库为 [`aio-mc-rcon`](https://github.com/Iapetus-11/aio-mc-rcon)
 
 ## 其他
 

--- a/nonebot/adapters/minecraft/adapter.py
+++ b/nonebot/adapters/minecraft/adapter.py
@@ -309,8 +309,18 @@ class Adapter(BaseAdapter):
             with contextlib.suppress(Exception):
                 await websocket.close()
                 if rcon:
-                    await rcon.close()
-                    log("INFO", f"RCON for <y>Bot {escape_tag(self_id)}</y> closed")
+                    try:
+                        await asyncio.wait_for(rcon.close(), timeout=5.0)
+                        log("INFO", f"RCON for <y>Bot {escape_tag(bot.self_id)}</y> closed gracefully.")
+                    except asyncio.TimeoutError:
+                        log("WARNING", f"Closing RCON for <y>Bot {escape_tag(bot.self_id)}</y> timed out.")
+                    except Exception as e:
+                        log(
+                            "ERROR",
+                            f"An error occurred while closing RCON for <y>Bot {escape_tag(bot.self_id)}</y>.",
+                            e,
+                        )
+
             self.connections.pop(self_id, None)
             self.bot_disconnect(bot)
 

--- a/nonebot/adapters/minecraft/event/__init__.py
+++ b/nonebot/adapters/minecraft/event/__init__.py
@@ -11,112 +11,56 @@ from .base import (
 )
 
 # Fabric 事件
-from .fabric import (
-    Player as FabricPlayer,
-)
-from .fabric import (
-    ServerCommandMessageEvent as FabricServerCommandMessageEvent,
-)
-from .fabric import (
-    ServerLivingEntityAfterDeathEvent as FabricServerLivingEntityAfterDeathEvent,
-)
-from .fabric import (
-    ServerMessageEvent as FabricServerMessageEvent,
-)
-from .fabric import (
-    ServerPlayConnectionDisconnectEvent as FabricServerPlayConnectionDisconnectEvent,
-)
-from .fabric import (
-    ServerPlayConnectionJoinEvent as FabricServerPlayConnectionJoinEvent,
-)
+from .fabric import Player as FabricPlayer
+from .fabric import ServerCommandMessageEvent as FabricServerCommandMessageEvent
+from .fabric import ServerLivingEntityAfterDeathEvent as FabricServerLivingEntityAfterDeathEvent
+from .fabric import ServerMessageEvent as FabricServerMessageEvent
+from .fabric import ServerPlayConnectionDisconnectEvent as FabricServerPlayConnectionDisconnectEvent
+from .fabric import ServerPlayConnectionJoinEvent as FabricServerPlayConnectionJoinEvent
+
+# Folia 事件
+from .folia import AsyncPlayerChatEvent as FoliaAsyncPlayerChatEvent
+from .folia import Player as FoliaPlayer
+from .folia import PlayerCommandPreprocessEvent as FoliaPlayerCommandPreprocessEvent
+from .folia import PlayerDeathEvent as FoliaPlayerDeathEvent
+from .folia import PlayerJoinEvent as FoliaPlayerJoinEvent
+from .folia import PlayerQuitEvent as FoliaPlayerQuitEvent
 
 # Forge 事件
-from .forge import (
-    Player as ForgePlayer,
-)
-from .forge import (
-    PlayerCommandEvent as ForgePlayerCommandEvent,
-)
-from .forge import (
-    PlayerDeathEvent as ForgePlayerDeathEvent,
-)
-from .forge import (
-    PlayerLoggedInEvent as ForgePlayerLoggedInEvent,
-)
-from .forge import (
-    PlayerLoggedOutEvent as ForgePlayerLoggedOutEvent,
-)
-from .forge import (
-    ServerChatEvent as ForgeServerChatEvent,
-)
+from .forge import Player as ForgePlayer
+from .forge import PlayerCommandEvent as ForgePlayerCommandEvent
+from .forge import PlayerDeathEvent as ForgePlayerDeathEvent
+from .forge import PlayerLoggedInEvent as ForgePlayerLoggedInEvent
+from .forge import PlayerLoggedOutEvent as ForgePlayerLoggedOutEvent
+from .forge import ServerChatEvent as ForgeServerChatEvent
 
 # 原版事件
-from .minecraft import (
-    Player as MinecraftPlayer,
-)
-from .minecraft import (
-    PlayerChatEvent as MinecraftPlayerChatEvent,
-)
-from .minecraft import (
-    PlayerJoinEvent as MinecraftPlayerJoinEvent,
-)
-from .minecraft import (
-    PlayerQuitEvent as MinecraftPlayerQuitEvent,
-)
+from .minecraft import Player as MinecraftPlayer
+from .minecraft import PlayerChatEvent as MinecraftPlayerChatEvent
+from .minecraft import PlayerJoinEvent as MinecraftPlayerJoinEvent
+from .minecraft import PlayerQuitEvent as MinecraftPlayerQuitEvent
 
 # NeoForge 事件
-from .neoforge import (
-    Player as NeoForgePlayer,
-)
-from .neoforge import (
-    PlayerCommandEvent as NeoForgePlayerCommandEvent,
-)
-from .neoforge import (
-    PlayerDeathEvent as NeoForgePlayerDeathEvent,
-)
-from .neoforge import (
-    PlayerLoggedInEvent as NeoForgePlayerLoggedInEvent,
-)
-from .neoforge import (
-    PlayerLoggedOutEvent as NeoForgePlayerLoggedOutEvent,
-)
-from .neoforge import (
-    ServerChatEvent as NeoForgeServerChatEvent,
-)
-from .spigot import (
-    AsyncPlayerChatEvent as SpigotAsyncPlayerChatEvent,
-)
+from .neoforge import Player as NeoForgePlayer
+from .neoforge import PlayerCommandEvent as NeoForgePlayerCommandEvent
+from .neoforge import PlayerDeathEvent as NeoForgePlayerDeathEvent
+from .neoforge import PlayerLoggedInEvent as NeoForgePlayerLoggedInEvent
+from .neoforge import PlayerLoggedOutEvent as NeoForgePlayerLoggedOutEvent
+from .neoforge import ServerChatEvent as NeoForgeServerChatEvent
+from .spigot import AsyncPlayerChatEvent as SpigotAsyncPlayerChatEvent
 
 # Spigot 事件
-from .spigot import (
-    Player as SpigotPlayer,
-)
-from .spigot import (
-    PlayerCommandPreprocessEvent as SpigotPlayerCommandPreprocessEvent,
-)
-from .spigot import (
-    PlayerDeathEvent as SpigotPlayerDeathEvent,
-)
-from .spigot import (
-    PlayerJoinEvent as SpigotPlayerJoinEvent,
-)
-from .spigot import (
-    PlayerQuitEvent as SpigotPlayerQuitEvent,
-)
-from .velocity import (
-    CommandExecuteEvent as VelocityCommandExecuteEvent,
-)
-from .velocity import (
-    DisconnectEvent as VelocityDisconnectEvent,
-)
+from .spigot import Player as SpigotPlayer
+from .spigot import PlayerCommandPreprocessEvent as SpigotPlayerCommandPreprocessEvent
+from .spigot import PlayerDeathEvent as SpigotPlayerDeathEvent
+from .spigot import PlayerJoinEvent as SpigotPlayerJoinEvent
+from .spigot import PlayerQuitEvent as SpigotPlayerQuitEvent
+from .velocity import CommandExecuteEvent as VelocityCommandExecuteEvent
+from .velocity import DisconnectEvent as VelocityDisconnectEvent
 
 # Velocity 事件
-from .velocity import (
-    LoginEvent as VelocityLoginEvent,
-)
-from .velocity import (
-    PlayerChatEvent as VelocityPlayerChatEvent,
-)
+from .velocity import LoginEvent as VelocityLoginEvent
+from .velocity import PlayerChatEvent as VelocityPlayerChatEvent
 
 __all__ = [
     "BaseChatEvent",
@@ -134,6 +78,13 @@ __all__ = [
     "FabricServerMessageEvent",
     "FabricServerPlayConnectionDisconnectEvent",
     "FabricServerPlayConnectionJoinEvent",
+    # Folia
+    "FoliaAsyncPlayerChatEvent",
+    "FoliaPlayer",
+    "FoliaPlayerCommandPreprocessEvent",
+    "FoliaPlayerDeathEvent",
+    "FoliaPlayerJoinEvent",
+    "FoliaPlayerQuitEvent",
     # Forge
     "ForgePlayer",
     "ForgePlayerCommandEvent",

--- a/nonebot/adapters/minecraft/event/base.py
+++ b/nonebot/adapters/minecraft/event/base.py
@@ -51,7 +51,7 @@ class Event(BaseEvent):
         return False
 
     if PYDANTIC_V2:
-        model_config = ConfigDict(extra="allow")
+        model_config = ConfigDict(extra="allow")  # type: ignore
     else:
 
         class Config(ConfigDict):
@@ -67,7 +67,7 @@ class BasePlayer(BaseModel):
     is_op: bool | None = None
 
     if PYDANTIC_V2:
-        model_config = ConfigDict(extra="allow")
+        model_config = ConfigDict(extra="allow")  # type: ignore
     else:
 
         class Config(ConfigDict):

--- a/nonebot/adapters/minecraft/event/folia.py
+++ b/nonebot/adapters/minecraft/event/folia.py
@@ -1,0 +1,70 @@
+from typing import Literal
+
+from .base import (
+    BaseChatEvent,
+    BaseDeathEvent,
+    BaseJoinEvent,
+    BasePlayer,
+    BasePlayerCommandEvent,
+    BaseQuitEvent,
+)
+
+
+class Player(BasePlayer):
+    """Folia Player"""
+
+    display_name: str | None = None
+    player_list_name: str | None = None
+    is_health_scaled: bool | None = None
+    address: str | None = None
+    is_sprinting: bool | None = None
+    walk_speed: float | None = None
+    fly_speed: float | None = None
+    is_sneaking: bool | None = None
+    level: int | None = None
+    is_flying: bool | None = None
+    ping: int | None = None
+    allow_flight: bool | None = None
+    locale: str | None = None
+    health_scale: float | None = None
+    player_time_offset: int | None = None
+    exp: float | None = None
+    total_exp: int | None = None
+    player_time: int | None = None
+    is_player_time_relative: bool | None = None
+    is_op: bool | None = None
+
+
+class AsyncPlayerChatEvent(BaseChatEvent):
+    """Folia 聊天事件"""
+
+    event_name: Literal["FoliaAsyncPlayerChatEvent"]
+    player: Player
+
+
+class PlayerCommandPreprocessEvent(BasePlayerCommandEvent):
+    """Folia 玩家命令事件"""
+
+    event_name: Literal["FoliaPlayerCommandPreprocessEvent"]
+    player: Player
+
+
+class PlayerDeathEvent(BaseDeathEvent):
+    """Folia 玩家死亡事件"""
+
+    event_name: Literal["FoliaPlayerDeathEvent"]
+    player: Player
+
+
+class PlayerJoinEvent(BaseJoinEvent):
+    """Folia 玩家加入事件"""
+
+    event_name: Literal["FoliaPlayerJoinEvent"]
+    player: Player
+
+
+class PlayerQuitEvent(BaseQuitEvent):
+    """Folia 玩家离开事件"""
+
+    event_name: Literal["FoliaPlayerQuitEvent"]
+    player: Player

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nonebot-adapter-minecraft"
-version = "1.5.0"
+version = "1.5.1"
 description = "NoneBot2与MineCraft Server互通的适配器。"
 authors = ["17TheWord <17theword@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Sourcery 摘要

关闭 RCON 连接时应用 5 秒超时和增强日志记录，并将包版本更新至 1.5.1。

错误修复：
- 通过对 RCON.close 调用应用超时，防止关闭 RCON 时无限期挂起。

增强功能：
- 关闭 RCON 时，为正常关闭、超时和错误添加日志记录。

构建：
- 将适配器版本提升至 1.5.1。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Apply a 5-second timeout and enhanced logging when closing RCON connections, and update package version to 1.5.1.

Bug Fixes:
- Prevent indefinite hang when closing RCON by applying a timeout to RCON.close calls.

Enhancements:
- Add logging for graceful closure, timeouts, and errors when closing RCON.

Build:
- Bump adapter version to 1.5.1.

</details>