### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ __pycache__/
 # C extensions
 *.so
 
+.wakatime-project
+
+.vscode/
+
 # Distribution / packaging
 .Python
 build/

--- a/nonebot/adapters/minecraft/models.py
+++ b/nonebot/adapters/minecraft/models.py
@@ -76,7 +76,15 @@ class HoverEvent(BaseModel):
     """悬停事件类型。"""
 
     contents: "Component | str | list[Component] | HoverShowItem | HoverShowEntity | None" = None
-    """悬停显示内容，可为文本、物品或实体信息。"""
+    """悬停显示内容，可为文本、物品或实体信息。1.16及以上"""
+
+    value: "Component | str | list[Component] | HoverShowItem | HoverShowEntity | None" = None
+    """悬停显示内容，可为文本、物品或实体信息。1.15及以下"""
+
+    def __setattr__(self, name: str, value: Any):
+        super().__setattr__(name, value)
+        if name == "contents" and value is not None:
+            super().__setattr__("value", value)
 
 
 class Color(str, Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot-adapter-minecraft"
-version = "1.8.0"
+version = "1.8.1"
 description = "NoneBot2与MineCraft Server互通的适配器。"
 authors = [{ name = "17TheWord", email = "17theword@gmail.com" }]
 requires-python = ">=3.10,<4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "nonebot-adapter-minecraft"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "nonebot2", extra = ["fastapi", "httpx", "websockets"] },


### PR DESCRIPTION
## Summary by Sourcery

添加向后兼容的鼠标悬停事件字段处理，并更新包版本。

Bug 修复：
- 恢复对使用 `value` 字段而非 `contents` 字段的旧版 Minecraft 悬停事件负载的支持。

增强：
- 使悬停事件的 `contents` 和 `value` 字段保持同步，以透明支持多个 Minecraft 协议版本。

构建：
- 将 nonebot-adapter-minecraft 包版本提升至 1.8.1。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add backward-compatible hover event field handling and bump package version.

Bug Fixes:
- Restore support for legacy Minecraft hover event payloads that use the value field instead of contents.

Enhancements:
- Keep hover event contents and value fields synchronized to transparently support multiple Minecraft protocol versions.

Build:
- Bump nonebot-adapter-minecraft package version to 1.8.1.

</details>